### PR TITLE
options.html: Increase keyword_xf maxlength

### DIFF
--- a/options.html
+++ b/options.html
@@ -88,7 +88,7 @@ License:
 				</div>
 				<br/>
 				<form>
-					<input type="text" id="keyword_cf" maxlength="20"/>
+					<input type="text" id="keyword_cf" maxlength="120" size="20"/>
 					<input type="button" id="add_cf" value="Add"/>
 					<label><input id="bu" type="radio" name="group1" value="0"/> Block Site</label>
 					<label><input id="bw" type="radio" name="group1" value="1"/> Block Keyword</label>
@@ -109,7 +109,7 @@ License:
 				</div>
 				<br/>
 				<form>
-					<input type="text" id="keyword_pf" maxlength="20"/>
+					<input type="text" id="keyword_pf" maxlength="120" size="20"/>
 					<input type="button" id="add_pf" value="Add"/>
 				</form>
 			</div>


### PR DESCRIPTION
Increase keyword_cf and keyword_pf maxlength to 120 characters, but maintain the 20 char input field with size=20.

I could find no restriction of characters in the corresponding js code or any other reason why this would be a breaking change.
